### PR TITLE
Fix Travis

### DIFF
--- a/test_changes.gemspec
+++ b/test_changes.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Your travis tests are failing because you specified `bundler ~> 1.8` in your gemspec. Travis only has bundler 1.7. There's no need to specify bundler in your gemspec, anyway, so I removed it.
